### PR TITLE
Exclude secret keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Config.GOOGLE_MAPS_API_KEY; // 'abcdefgh'
 
 Keep in mind this module doesn't obfuscate or encrypt secrets for packaging, so **do not store sensitive keys in `.env`**. It's [basically impossible to prevent users from reverse engineering mobile app secrets](https://rammic.github.io/2015/07/28/hiding-secrets-in-android-apps/), so design your app (and APIs) with that in mind.
 
+## Excluding vars
+
+Sometimes you will need to include vars in your `.env` not required for your app to run but rather for a CI process and so you can prefix the key name with `SECRET` to exclude it.
+
+```
+API_URL=https://myapi.com
+SECRET_CI_API_KEY=abcdefgh # this will not be available in the app
+```
+
 ## Setup
 
 Install the package:

--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -52,6 +52,9 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
             def matcher = (line =~ /^\s*(?:export\s+|)([\w\d\.\-_]+)\s*=\s*['"]?(.*?)?['"]?\s*$/)
             // TODO: Fail Android builds if line doesn't match
             if (matcher.getCount() == 1 && matcher[0].size() == 3) {
+                if (key.startsWith("SECRET_")) {
+                  return
+                }
                 env.put(matcher[0][1], matcher[0][2].replace('"', '\\"'))
             }
         }

--- a/ios/ReactNativeConfig/ReadDotEnv.rb
+++ b/ios/ReactNativeConfig/ReadDotEnv.rb
@@ -48,6 +48,7 @@ def read_dot_env(envs_root)
         abort('Invalid entry in .env file. Please verify your .env file is correctly formatted.')
       end
 
+      next h if m[:key].start_with?("SECRET_")
       key = m[:key]
       # Ensure string (in case of empty value) and escape any quotes present in the value.
       val = m[:val].to_s.gsub('"', '\"')


### PR DESCRIPTION
We have a single `.env` file that both our app and build process will use and in order to avoid including secret keys in the app we need to somehow exclude them from being built into the app.

This solution allows you to prefix a key with `SECRET_` to exclude it from being built into the app.