### PR TITLE
feat: add visionOS support

### DIFF
--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
   s.license      = 'MIT'
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
+  s.visionos.deployment_target = '1.0'
 
   s.source       = { git: 'https://github.com/luggit/react-native-config.git', tag: "v#{s.version.to_s}" }
   s.script_phase = {


### PR DESCRIPTION
Add support for [React Native visionOS](https://github.com/callstack/react-native-visionos), the new out-of-tree platform.

This only adds a new platform to the podspec, so the module can be installed in visionOS. No changes to any existing functionality.

![Simulator Screenshot - Apple Vision Pro - 2024-03-17 at 22 53 27](https://github.com/lugg/react-native-config/assets/26878038/c6eb64f0-696b-4028-ae4e-8dd06a734947)
