### PR TITLE
fix(iOS): #591 track env file changes on each build

### DIFF
--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -20,12 +20,12 @@ Pod::Spec.new do |s|
   s.script_phase = {
     name: 'Config codegen',
     script: %(
-set -ex
-HOST_PATH="$SRCROOT/../.."
-"${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
-),
+      set -ex
+      HOST_PATH="$SRCROOT/../.."
+      "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
+    ),
     execution_position: :before_compile,
-    input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb'],
+    input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb', '$SRCROOT/../../.env', '$ENVFILE'],
     output_files: ['$BUILD_DIR/GeneratedInfoPlistDotEnv.h', '$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/GeneratedDotEnv.m']
   }
 
@@ -48,7 +48,7 @@ HOST_PATH="$SRCROOT/../.."
         "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
         ),
       execution_position: :before_compile,
-      input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb'],
+      input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb', '$SRCROOT/../../.env', '$ENVFILE'],
       output_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/GeneratedDotEnv.m']
     }
     ext.source_files = ['ios/**/RNCConfig.{h,m}', 'ios/**/GeneratedDotEnv.m']


### PR DESCRIPTION
### Why:
This is a fix for #591 , #698  and #788.

### What:
Updated the podspec's **input_files** to include default  `.env` and custom (passed with "ENVFILE") locations. This fix ensures that Xcode recognizes changes in `.env` files and re-runs the script phase accordingly.

I suggest that touching `BuildDotenvConfig.rb` is not the best solution, as it will re-run the script phase on every build, even if `.env` is unchanged.