### PR TITLE
Make visionos optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-config",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Expose config variables to React Native apps",
   "keywords": [
     "env",

--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
   s.macos.deployment_target = '10.15'
-  s.visionos.deployment_target = '1.0'
+  s.visionos.deployment_target = '1.0' if s.respond_to?(:visionos)
 
   s.source       = { git: 'https://github.com/luggit/react-native-config.git', tag: "v#{s.version.to_s}" }
   s.script_phase = {


### PR DESCRIPTION
Resolves #804 by only specifying a visionos deployment target if visionos is supported by the user's cocoapods version.