### PR TITLE
feat: add envFile and envFlavor to project.ext for android

### DIFF
--- a/android/dotenv.gradle
+++ b/android/dotenv.gradle
@@ -61,6 +61,8 @@ def loadDotEnv(flavor = getCurrentFlavor()) {
         println("**************************")
     }
 
+    project.ext.set("envFlavor", flavor)
+    project.ext.set("envFile", envFile)
     project.ext.set("env", env)
 }
 


### PR DESCRIPTION
Why:
This is a fix for https://github.com/lugg/react-native-config/issues/821.

What:

The suggestion is to add the envFile and envFlavor fields in project.ext