### PR TITLE
fix(ios): always run script

### DIFF
--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -27,6 +27,7 @@ HOST_PATH="$SRCROOT/../.."
 "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
 ),
     execution_position: :before_compile,
+    based_on_dependency_analysis: false,
     input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb'],
     output_files: ['$BUILD_DIR/GeneratedInfoPlistDotEnv.h', '$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/GeneratedDotEnv.m']
   }

--- a/react-native-config.podspec
+++ b/react-native-config.podspec
@@ -27,7 +27,7 @@ HOST_PATH="$SRCROOT/../.."
 "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
 ),
     execution_position: :before_compile,
-    based_on_dependency_analysis: false,
+    always_out_of_date: "1",
     input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb'],
     output_files: ['$BUILD_DIR/GeneratedInfoPlistDotEnv.h', '$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/GeneratedDotEnv.m']
   }
@@ -51,6 +51,7 @@ HOST_PATH="$SRCROOT/../.."
         "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig/BuildDotenvConfig.rb" "$HOST_PATH" "${PODS_TARGET_SRCROOT}/ios/ReactNativeConfig"
         ),
       execution_position: :before_compile,
+      always_out_of_date: "1",
       input_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/BuildDotenvConfig.rb'],
       output_files: ['$PODS_TARGET_SRCROOT/ios/ReactNativeConfig/GeneratedDotEnv.m']
     }


### PR DESCRIPTION
As the .env file could be anywhere (monorepo etc) specifying a specific .env file path won't work and knowing how important it is to have .env in sync, I think running this script on every build makes sense

Fixes issues [692](https://github.com/lugg/react-native-config/issues/692) and [591](https://github.com/lugg/react-native-config/issues/591)